### PR TITLE
Expose internals and add an option to disable AUTH/HELLO on new connection

### DIFF
--- a/command.go
+++ b/command.go
@@ -468,6 +468,11 @@ func (cmd *Cmd) readReply(rd *proto.Reader) (err error) {
 	return err
 }
 
+func (cmd *Cmd) ReadReply(rd *proto.Reader) (err error) {
+	cmd.val, err = rd.ReadReply()
+	return err
+}
+
 //------------------------------------------------------------------------------
 
 type SliceCmd struct {

--- a/internal/proto/writer.go
+++ b/internal/proto/writer.go
@@ -59,6 +59,10 @@ func (w *Writer) writeLen(n int) error {
 	return err
 }
 
+func (w *Writer) WriteLen(n int) error {
+	return w.writeLen(n)
+}
+
 func (w *Writer) WriteArg(v interface{}) error {
 	switch v := v.(type) {
 	case nil:

--- a/options.go
+++ b/options.go
@@ -128,6 +128,10 @@ type Options struct {
 
 	// Enables read only queries on slave/follower nodes.
 	readOnly bool
+
+	// DisableAuthOnConnect (Teleport) disables sending AUTH or HELLO commands
+	// on new connection.
+	DisableAuthOnConnect bool
 }
 
 func (opt *Options) init() {

--- a/proto.go
+++ b/proto.go
@@ -1,0 +1,23 @@
+package redis
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/go-redis/redis/v9/internal/proto"
+)
+
+type Reader = proto.Reader
+type Writer = proto.Writer
+type RedisError = proto.RedisError
+
+const RespArray = proto.RespArray
+const RespInt = proto.RespInt
+
+func NewReader(rd io.Reader) *Reader {
+	return proto.NewReader(rd)
+}
+
+func NewWriter(wr *bytes.Buffer) *Writer {
+	return proto.NewWriter(wr)
+}

--- a/redis.go
+++ b/redis.go
@@ -221,45 +221,47 @@ func (c *baseClient) initConn(ctx context.Context, cn *pool.Conn) error {
 	}
 	cn.Inited = true
 
-	username, password := c.opt.Username, c.opt.Password
-	if c.opt.CredentialsProvider != nil {
-		username, password = c.opt.CredentialsProvider()
-	}
-
 	connPool := pool.NewSingleConnPool(c.connPool, cn)
 	conn := newConn(c.opt, connPool)
 
-	var auth bool
+	if !c.opt.DisableAuthOnConnect {
+		username, password := c.opt.Username, c.opt.Password
+		if c.opt.CredentialsProvider != nil {
+			username, password = c.opt.CredentialsProvider()
+		}
 
-	// For redis-server < 6.0 that does not support the Hello command,
-	// we continue to provide services with RESP2.
-	if err := conn.Hello(ctx, 3, username, password, "").Err(); err == nil {
-		auth = true
-	} else if !strings.HasPrefix(err.Error(), "ERR unknown command") {
-		return err
-	}
+		var auth bool
 
-	_, err := conn.Pipelined(ctx, func(pipe Pipeliner) error {
-		if !auth && password != "" {
-			if username != "" {
-				pipe.AuthACL(ctx, username, password)
-			} else {
-				pipe.Auth(ctx, password)
+		// For redis-server < 6.0 that does not support the Hello command,
+		// we continue to provide services with RESP2.
+		if err := conn.Hello(ctx, 3, username, password, "").Err(); err == nil {
+			auth = true
+		} else if !strings.HasPrefix(err.Error(), "ERR unknown command") {
+			return err
+		}
+
+		_, err := conn.Pipelined(ctx, func(pipe Pipeliner) error {
+			if !auth && password != "" {
+				if username != "" {
+					pipe.AuthACL(ctx, username, password)
+				} else {
+					pipe.Auth(ctx, password)
+				}
 			}
-		}
 
-		if c.opt.DB > 0 {
-			pipe.Select(ctx, c.opt.DB)
-		}
+			if c.opt.DB > 0 {
+				pipe.Select(ctx, c.opt.DB)
+			}
 
-		if c.opt.readOnly {
-			pipe.ReadOnly(ctx)
-		}
+			if c.opt.readOnly {
+				pipe.ReadOnly(ctx)
+			}
 
-		return nil
-	})
-	if err != nil {
-		return err
+			return nil
+		})
+		if err != nil {
+			return err
+		}
 	}
 
 	if c.opt.OnConnect != nil {


### PR DESCRIPTION
Changes:
- pulled upstream [`v9.0.0-rc1`](https://github.com/go-redis/redis/releases/tag/v9.0.0-rc.1) to branch `release/v9.0.0-rc.1`
- Re-applied  #1 here 
- Added an option to disable AUTH/HELLO on new connection
   - this is to avoid the client automatically sending HELLO 3 to the server for resp3. resp3 or not should be controlled by the Teleport engine so auth will be "manually" handled by the Teleport engine through `OnConnect` callback
