### PR TITLE
Fix an issue writer cannot write status type (+)

### DIFF
--- a/internal/proto/reader.go
+++ b/internal/proto/reader.go
@@ -31,6 +31,9 @@ const (
 	RespPush      = '>' // ><len>\r\n... (same as Array)
 )
 
+// StatusString is the read golang type of the RespStatus.
+type StatusString string
+
 // Not used temporarily.
 // Redis has not used these two data types for the time being, and will implement them later.
 // Streamed           = "EOF:"
@@ -159,7 +162,7 @@ func (r *Reader) ReadReply() (interface{}, error) {
 
 	switch line[0] {
 	case RespStatus:
-		return string(line[1:]), nil
+		return StatusString(line[1:]), nil
 	case RespInt:
 		return util.ParseInt(line[1:], 10, 64)
 	case RespFloat:

--- a/internal/proto/writer.go
+++ b/internal/proto/writer.go
@@ -69,6 +69,8 @@ func (w *Writer) WriteArg(v interface{}) error {
 		return w.string("")
 	case string:
 		return w.string(v)
+	case StatusString:
+		return w.status(v)
 	case []byte:
 		return w.bytes(v)
 	case int:
@@ -129,6 +131,18 @@ func (w *Writer) bytes(b []byte) error {
 	}
 
 	if _, err := w.Write(b); err != nil {
+		return err
+	}
+
+	return w.crlf()
+}
+
+func (w *Writer) status(s StatusString) error {
+	if err := w.WriteByte(RespStatus); err != nil {
+		return err
+	}
+
+	if _, err := w.Write([]byte(s)); err != nil {
 		return err
 	}
 

--- a/internal/proto/writer_test.go
+++ b/internal/proto/writer_test.go
@@ -100,3 +100,30 @@ func BenchmarkWriteBuffer_Append(b *testing.B) {
 		}
 	}
 }
+
+func TestWriteStatus(t *testing.T) {
+	inputStatusBytes := []byte("+status\r\n")
+
+	// Read it.
+	reader := proto.NewReader(bytes.NewReader(inputStatusBytes))
+	readStatus, err := reader.ReadReply()
+	if err != nil {
+		t.Errorf("Failed to ReadReply: %v", err)
+	}
+
+	if readStatus != proto.StatusString("status") {
+		t.Errorf("expect read %v but got %v", "status", readStatus)
+	}
+
+	// Write it.
+	outputStatusBytes := new(bytes.Buffer)
+	writer := proto.NewWriter(outputStatusBytes)
+	err = writer.WriteArg(readStatus)
+	if err != nil {
+		t.Errorf("Failed to WriteArg: %v", err)
+	}
+
+	if string(inputStatusBytes) != outputStatusBytes.String() {
+		t.Errorf("expect written %v but got %v", string(inputStatusBytes), outputStatusBytes.String())
+	}
+}


### PR DESCRIPTION
Related issue:
https://github.com/gravitational/teleport/pull/18776

Cause:
Driver reads `+<status>` as a golang `string` so writer will write `$<len><status>` instead of `+<status>`

Change:
Define a type alias `type StatusString string` and write `+<status>` if interface is `StatusString`

I think we should also update upstream. Will create a PR to upstream if we all agree.