### PR TITLE
Enable StatusString for all readers

### DIFF
--- a/internal/proto/reader.go
+++ b/internal/proto/reader.go
@@ -55,28 +55,13 @@ func ParseErrorReply(line []byte) error {
 
 //------------------------------------------------------------------------------
 
-type readerOpt struct {
-	// useStatusStringType uses `StatusString` type instead of string for RespStatus.
-	useStatusStringType bool
-}
-
-func ReaderOptUseStatusStringType(o *readerOpt) {
-	o.useStatusStringType = true
-}
-
 type Reader struct {
-	rd  *bufio.Reader
-	opt readerOpt
+	rd *bufio.Reader
 }
 
-func NewReader(rd io.Reader, opts ...func(o *readerOpt)) *Reader {
-	opt := readerOpt{}
-	for _, applyOpt := range opts {
-		applyOpt(&opt)
-	}
+func NewReader(rd io.Reader) *Reader {
 	return &Reader{
-		rd:  bufio.NewReader(rd),
-		opt: opt,
+		rd: bufio.NewReader(rd),
 	}
 }
 
@@ -177,10 +162,7 @@ func (r *Reader) ReadReply() (interface{}, error) {
 
 	switch line[0] {
 	case RespStatus:
-		if r.opt.useStatusStringType {
-			return StatusString(line[1:]), nil
-		}
-		return string(line[1:]), nil
+		return StatusString(line[1:]), nil
 	case RespInt:
 		return util.ParseInt(line[1:], 10, 64)
 	case RespFloat:

--- a/internal/proto/writer_test.go
+++ b/internal/proto/writer_test.go
@@ -105,7 +105,7 @@ func TestWriteStatus(t *testing.T) {
 	inputStatusBytes := []byte("+status\r\n")
 
 	// Read it.
-	reader := proto.NewReader(bytes.NewReader(inputStatusBytes), proto.ReaderOptUseStatusStringType)
+	reader := proto.NewReader(bytes.NewReader(inputStatusBytes))
 	readStatus, err := reader.ReadReply()
 	if err != nil {
 		t.Errorf("Failed to ReadReply: %v", err)

--- a/proto.go
+++ b/proto.go
@@ -15,7 +15,7 @@ const RespArray = proto.RespArray
 const RespInt = proto.RespInt
 
 func NewReader(rd io.Reader) *Reader {
-	return proto.NewReader(rd, proto.ReaderOptUseStatusStringType)
+	return proto.NewReader(rd)
 }
 
 func NewWriter(wr *bytes.Buffer) *Writer {

--- a/pubsub.go
+++ b/pubsub.go
@@ -366,6 +366,10 @@ func (p *Pong) String() string {
 
 func (c *PubSub) newMessage(reply interface{}) (interface{}, error) {
 	switch reply := reply.(type) {
+	case proto.StatusString:
+		return &Pong{
+			Payload: string(reply),
+		}, nil
 	case string:
 		return &Pong{
 			Payload: reply,

--- a/redis_test.go
+++ b/redis_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/bsm/gomega"
 
 	"github.com/redis/go-redis/v9"
+	"github.com/redis/go-redis/v9/internal/proto"
 )
 
 type redisHookError struct{}
@@ -192,7 +193,7 @@ var _ = Describe("Client", func() {
 		Expect(client.Echo(ctx, "hello").Err()).NotTo(HaveOccurred())
 
 		Expect(cmd.Err()).NotTo(HaveOccurred())
-		Expect(cmd.Val()).To(Equal("PONG"))
+		Expect(cmd.Val()).To(Equal(proto.StatusString("PONG")))
 	})
 
 	It("should retry command on network error", func() {


### PR DESCRIPTION
Related
- #37 
- https://github.com/gravitational/teleport/issues/33564

In #37, a `readerOpt` was added as an option to enable `StatusString` to workaround UT issues. However, this means the default connection pool does *NOT* have this flag *ENABLED*,  thus making the original `StatusString` fix *USELESS*. 😭 

This PR reverted the `readerOpt` part and fixed the other UTs properly.

I did consider pushing the `StatusString` fix upstream but it's clear that this breaks backward compatibility as `cmd.Val()` will return a `proto.StatusString` instead of `string`.

Will need to revisit later to see if possible to make an upstream acceptable version of the fix or maybe fix this entirely on the Teleport side without driver change.

Also there are some testing escapes. Will add a "COMMAND DOCS" test at a higher level in teleport repo. And for e2e testing, we should always test out a user with full permission (I didn't catch this because my users do not have `COMMAND DOCS` permission to trigger this case)